### PR TITLE
New search() behavior, yielding tweets instead of returning HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ One of the following needs to be installed and available on your system's `PATH`
 ## Small example:
 
     import json
-    import twitterwebsearch
+    import twitterwebsearch.searcher
     import twitterwebsearch.parser
     
     QUERY = '@shinnonoir since:2010-01-20 until:2010-02-01'
     
     
     def main():
-        results = twitterwebsearch.search(QUERY)
+        results = twitterwebsearch.searcher.search_html(QUERY)
         tweets = twitterwebsearch.parser.parse_search_results(results)
         tweets = list(tweets) # convert generator into list
         print json.dumps(tweets, indent=2)

--- a/README.md
+++ b/README.md
@@ -21,15 +21,12 @@ One of the following needs to be installed and available on your system's `PATH`
 ## Small example:
 
     import json
-    import twitterwebsearch.searcher
-    import twitterwebsearch.parser
+    import twitterwebsearch
     
     QUERY = '@shinnonoir since:2010-01-20 until:2010-02-01'
     
-    
     def main():
-        results = twitterwebsearch.searcher.search_html(QUERY)
-        tweets = twitterwebsearch.parser.parse_search_results(results)
+        tweets = twitterwebsearch.search(QUERY)
         tweets = list(tweets) # convert generator into list
         print json.dumps(tweets, indent=2)
     

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -3,15 +3,13 @@ Quickstart example.
 '''
 
 import json
-import twitterwebsearch.searcher
-import twitterwebsearch.parser
+import twitterwebsearch
 import twitterwebsearch.io
 
 QUERY = '@shinnonoir since:2010-01-20 until:2010-02-01'
 
 def main():
-    results = twitterwebsearch.searcher.search_html(QUERY)
-    tweets = twitterwebsearch.parser.parse_search_results(results)
+    tweets = twitterwebsearch.search(QUERY)
     tweets = list(tweets) # convert generator into list
     
     print json.dumps(tweets, indent=2)

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -3,14 +3,14 @@ Quickstart example.
 '''
 
 import json
-import twitterwebsearch
+import twitterwebsearch.searcher
 import twitterwebsearch.parser
 import twitterwebsearch.io
 
 QUERY = '@shinnonoir since:2010-01-20 until:2010-02-01'
 
 def main():
-    results = twitterwebsearch.search(QUERY)
+    results = twitterwebsearch.searcher.search_html(QUERY)
     tweets = twitterwebsearch.parser.parse_search_results(results)
     tweets = list(tweets) # convert generator into list
     

--- a/examples/without_date_range.py
+++ b/examples/without_date_range.py
@@ -1,0 +1,25 @@
+'''
+Example without date range.
+'''
+
+import time
+import twitterwebsearch
+
+QUERY = 'president'
+CUTOFF = 500
+
+def main():
+    start_time = time.time()
+    for i, tweet in enumerate(twitterwebsearch.search(QUERY)):
+        n = i+1
+        print '%s tweets crawled...\r' % n,
+        
+        if n >= CUTOFF:
+            break
+    
+    end_time = time.time()
+    
+    print '\nTook %s seconds' % (end_time - start_time) 
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ that is only available through the Twitter web interface
 
 setup(
     name = 'twitterwebsearch',
-    version='0.0.5',
+    version='0.1.1',
     author = 'Raynor Vliegendhart',
     author_email = 'ShinNoNoir@gmail.com',
     url = 'https://github.com/ShinNoNoir/twitterwebsearch',

--- a/twitterwebsearch/parser.py
+++ b/twitterwebsearch/parser.py
@@ -25,6 +25,7 @@ def parse_tweet_tag(tag):
     urls = [
         a['data-expanded-url']
         for a in tweet_body_tag.find_all('a', class_=has_class('twitter-timeline-link'))
+        if 'data-expanded-url' in a.attrs
     ]
     
     mentions = [

--- a/twitterwebsearch/searcher.py
+++ b/twitterwebsearch/searcher.py
@@ -4,6 +4,8 @@ Module for using the web interface of Twitter's search.
 import sys
 import time
 import datetime
+import twitterwebsearch.parser
+
 from selenium.common.exceptions import NoSuchElementException
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
@@ -19,6 +21,37 @@ SCROLLER_SCRIPT = '''
     footer = document.getElementsByClassName('stream-footer')[0];
     scroller = setInterval(function() { footer.scrollIntoView(); }, 250);
 '''
+
+LOAD_MORE_TWEETS_FUNCTION_NAME = 'load_more_tweets'
+LOAD_MORE_TWEETS_FUNCTION = LOAD_MORE_TWEETS_FUNCTION_NAME + '();'
+LOAD_MORE_TWEETS_SCRIPT = '''
+footer = document.getElementsByClassName('stream-footer')[0];
+%s = function () {
+    document.body.classList.remove('more-tweets-loaded');
+    var tweets = document.querySelectorAll('.tweet[data-tweet-id]');
+    
+    function removeTweets() {
+        var more = document.querySelector(".timeline-end.has-more-items") !== null;
+        var not_loaded = document.querySelectorAll('.tweet[data-tweet-id]').length === tweets.length;
+        if (more && not_loaded) {
+            window.setTimeout(removeTweets, 250);
+        }
+        else {
+            document.body.scrollIntoView()
+            for (var i=0; i < tweets.length; i++) {
+                elem = tweets[i];
+                elem.parentNode.removeChild(elem);
+            }
+            document.body.classList.add('more-tweets-loaded');
+        }
+    };
+    removeTweets();
+    footer.scrollIntoView();
+}
+''' % LOAD_MORE_TWEETS_FUNCTION_NAME
+MORE_TWEETS_LOADED_CLASS = 'more-tweets-loaded'
+MORE_TWEETS_LOADED_TIMEOUT = 5 # seconds
+
 LIVE_TWEETS_SELECTOR = 'a[href*="f=tweets"]'
 
 DRIVER_PRIORITY = [webdriver.PhantomJS, webdriver.Firefox]
@@ -84,7 +117,32 @@ def start_search(driver, query):
         
 
 def search(query):
-    return search_html(query)
+    driver = create_driver()
+    try:
+        start_search(driver, query)
+        driver.execute_script(LOAD_MORE_TWEETS_SCRIPT)
+        
+        more_tweets = True
+        while more_tweets:
+            source = driver.page_source
+            driver.execute_script(LOAD_MORE_TWEETS_FUNCTION)
+            
+            more_tweets = False
+            tweets = twitterwebsearch.parser.parse_search_results(source)
+            for tweet in tweets:
+                more_tweets = True
+                yield tweet
+            
+            WebDriverWait(driver, MORE_TWEETS_LOADED_TIMEOUT).until(
+                EC.presence_of_element_located((By.CLASS_NAME, MORE_TWEETS_LOADED_CLASS))
+            )
+            
+        
+    except:
+        debug_screenshot(driver)
+        raise
+    finally:
+        driver.quit()
 
 def search_html(query):
     driver = create_driver()

--- a/twitterwebsearch/searcher.py
+++ b/twitterwebsearch/searcher.py
@@ -61,6 +61,9 @@ def wait_until_url(driver, predicate, sleep=0.25):
     
 
 def search(query):
+    return search_html(query)
+
+def search_html(query):
     driver = create_driver()
     driver.get(TWITTER_SEARCH_URL)
     

--- a/twitterwebsearch/searcher.py
+++ b/twitterwebsearch/searcher.py
@@ -60,18 +60,13 @@ def wait_until_url(driver, predicate, sleep=0.25):
         time.sleep(sleep)
     
 
-def search(query):
-    return search_html(query)
-
-def search_html(query):
-    driver = create_driver()
+def start_search(driver, query):
     driver.get(TWITTER_SEARCH_URL)
     
     elem = driver.find_element_by_id(SEARCH_FIELD)
     elem.send_keys(query)
     elem.send_keys(Keys.ENTER)
     
-    res = ''
     try:
         elem = WebDriverWait(driver, QUERY_TIMEOUT).until(
             EC.presence_of_element_located((By.CLASS_NAME, WAIT_FOR_CLASS))
@@ -83,6 +78,20 @@ def search_html(query):
             raise
         
         wait_until_url(driver, predicate=lambda url: '&f=tweets' in url)
+    except:
+        debug_screenshot(driver)
+        raise
+        
+
+def search(query):
+    return search_html(query)
+
+def search_html(query):
+    driver = create_driver()
+    
+    res = ''
+    try:
+        start_search(driver, query)
         driver.execute_script(SCROLLER_SCRIPT)
         
         old_size = size = 0

--- a/twitterwebsearch/searcher.py
+++ b/twitterwebsearch/searcher.py
@@ -37,7 +37,7 @@ footer = document.getElementsByClassName('stream-footer')[0];
             window.setTimeout(removeTweets, 250);
         }
         else {
-            document.body.scrollIntoView()
+            document.body.scrollIntoView();
             for (var i=0; i < tweets.length; i++) {
                 elem = tweets[i];
                 elem.parentNode.removeChild(elem);

--- a/twitterwebsearch/searcher.py
+++ b/twitterwebsearch/searcher.py
@@ -50,7 +50,7 @@ footer = document.getElementsByClassName('stream-footer')[0];
 }
 ''' % LOAD_MORE_TWEETS_FUNCTION_NAME
 MORE_TWEETS_LOADED_CLASS = 'more-tweets-loaded'
-MORE_TWEETS_LOADED_TIMEOUT = 5 # seconds
+MORE_TWEETS_LOADED_TIMEOUT = 10 # seconds
 
 LIVE_TWEETS_SELECTOR = 'a[href*="f=tweets"]'
 


### PR DESCRIPTION
# Introducing new search behavior

This change breaks old code. The `search` function now yields tweets instead of returning an HTML string which would have to be parsed by the caller in an additional step. The new behavior interleaves parsing and loading more tweets, allowing the implementation to prune the DOM tree in the browser process. This should reduce overall memory consumption.

The old behavior is still accessible via `twitterwebsearch.searcher.search_html`.
