### PR TITLE
Fix for Issue 5: censored tweet causes an exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ that is only available through the Twitter web interface
 
 setup(
     name = 'twitterwebsearch',
-    version='0.2.0',
+    version='0.2.1',
     author = 'Raynor Vliegendhart',
     author_email = 'ShinNoNoir@gmail.com',
     url = 'https://github.com/ShinNoNoir/twitterwebsearch',

--- a/twitterwebsearch/parser.py
+++ b/twitterwebsearch/parser.py
@@ -19,6 +19,10 @@ def parse_tweet_tag(tag):
     content_div = tag.find('div', class_=has_class('content'))
     tweet_body_tag = content_div.find('p', class_=has_class('tweet-text'))
     
+    if tweet_body_tag is None:
+        # Might be a censored tweet, skip
+        return
+    
     lang = tweet_body_tag['lang']
     tweet_text = tweet_body_tag.text
     
@@ -64,5 +68,6 @@ def parse_search_results(html):
     soup_tweets = bs4.BeautifulSoup(html, 'html.parser', parse_only=only_tweet_tags)
     for tag in soup_tweets:
         tweet = parse_tweet_tag(tag)
-        yield tweet
+        if tweet is not None:
+            yield tweet
 


### PR DESCRIPTION
Censored tweets don't have a tweet-text. The function `parse_tweet_tag` may now return None if it cannot return a valid tweet.
