### PR TITLE
Issue7: Fix stop condition for requesting more tweets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ that is only available through the Twitter web interface
 
 setup(
     name = 'twitterwebsearch',
-    version='0.2.1',
+    version='0.2.3',
     author = 'Raynor Vliegendhart',
     author_email = 'ShinNoNoir@gmail.com',
     url = 'https://github.com/ShinNoNoir/twitterwebsearch',

--- a/twitterwebsearch/searcher.py
+++ b/twitterwebsearch/searcher.py
@@ -37,6 +37,7 @@ def download_tweets(search=None, profile=None, sleep=DEFAULT_SLEEP):
         yield tweet
 
     has_more_items = True
+    last_min_position = None
     while has_more_items:
         response = requests.get(url_more.format(term=urllib.quote_plus(term), max_position=min_position), headers={'User-agent': USER_AGENT}).text
         try:
@@ -48,7 +49,7 @@ def download_tweets(search=None, profile=None, sleep=DEFAULT_SLEEP):
             raise
         
         min_position = response_dict['min_position']
-        has_more_items = response_dict['has_more_items'] if profile else False
+        has_more_items = response_dict['has_more_items'] if profile else last_min_position != min_position
 
         for tweet in parse_search_results(response_dict['items_html'].encode('utf8')):
             yield tweet
@@ -56,6 +57,7 @@ def download_tweets(search=None, profile=None, sleep=DEFAULT_SLEEP):
             if search:
                 has_more_items = True
 
+        last_min_position = min_position
         time.sleep(sleep)
 
 

--- a/twitterwebsearch/searcher.py
+++ b/twitterwebsearch/searcher.py
@@ -3,6 +3,7 @@ Module for using the web interface of Twitter's search.
 """
 import json
 import time
+import urllib
 import requests
 from twitterwebsearch.parser import parse_search_results
 
@@ -28,7 +29,7 @@ def download_tweets(search=None, profile=None, sleep=DEFAULT_SLEEP):
     url = TWITTER_SEARCH_URL if search else TWITTER_PROFILE_URL
     url_more = TWITTER_SEARCH_MORE_URL if search else TWITTER_PROFILE_MORE_URL
 
-    response = requests.get(url.format(term=term), headers={'User-agent': USER_AGENT}).text
+    response = requests.get(url.format(term=urllib.quote_plus(term)), headers={'User-agent': USER_AGENT}).text
     max_position = find_value(response, 'data-max-position')
     min_position = find_value(response, 'data-min-position')
 
@@ -37,7 +38,7 @@ def download_tweets(search=None, profile=None, sleep=DEFAULT_SLEEP):
 
     has_more_items = True
     while has_more_items:
-        response = requests.get(url_more.format(term=term, max_position=min_position), headers={'User-agent': USER_AGENT}).text
+        response = requests.get(url_more.format(term=urllib.quote_plus(term), max_position=min_position), headers={'User-agent': USER_AGENT}).text
         try:
             response_dict = json.loads(response)
         except:


### PR DESCRIPTION
Originally, the function `download_tweets` stopped requesting the Twitter service when no tweets were being returned. However, apparently (and perhaps recently) the service could return 0 tweets while more results were still available. The new stop condition comparse a field in the service's response (`min_position`, basically a database cursor) to its previous value in order to determine whether more results are available.

Original bug report: https://github.com/ShinNoNoir/twitterwebsearch/issues/7
