### PR TITLE
Issue9: Inclusion of emojis in tweet text and encoding fix when utf-8 is not the default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ that is only available through the Twitter web interface
 
 setup(
     name = 'twitterwebsearch',
-    version='0.2.3',
+    version='0.2.5',
     author = 'Raynor Vliegendhart',
     author_email = 'ShinNoNoir@gmail.com',
     url = 'https://github.com/ShinNoNoir/twitterwebsearch',

--- a/twitterwebsearch/parser.py
+++ b/twitterwebsearch/parser.py
@@ -70,7 +70,7 @@ def parse_tweet_tag(tag, expand_emojis=True):
     return tweet
     
 def parse_search_results(html):
-    soup_tweets = bs4.BeautifulSoup(html, 'html.parser', parse_only=only_tweet_tags)
+    soup_tweets = bs4.BeautifulSoup(html, 'html.parser', parse_only=only_tweet_tags, from_encoding='utf-8')
     for tag in soup_tweets:
         tweet = parse_tweet_tag(tag)
         if tweet is not None:

--- a/twitterwebsearch/parser.py
+++ b/twitterwebsearch/parser.py
@@ -9,7 +9,7 @@ def has_class(class_name):
 
 only_tweet_tags = bs4.SoupStrainer('div', class_=has_class('tweet'), **{'data-tweet-id': True})
 
-def parse_tweet_tag(tag):
+def parse_tweet_tag(tag, expand_emojis=True):
     tweet_id = tag['data-tweet-id']
     permalink = tag['data-permalink-path']
     screen_name = tag['data-screen-name']
@@ -22,6 +22,11 @@ def parse_tweet_tag(tag):
     if tweet_body_tag is None:
         # Might be a censored tweet, skip
         return
+    
+    if expand_emojis:
+        for emoji_tag in tweet_body_tag.find_all(class_='Emoji'):
+            emoji_tag.insert(0, emoji_tag['alt'])
+
     
     lang = tweet_body_tag['lang']
     tweet_text = tweet_body_tag.text


### PR DESCRIPTION
Emojis in tweets are represented by `<img>` tags in Twitter's web interface, but were previously not included in the text representation of the tweet. This pull request copies the value of the `<img>`'s `alt` attribute and inserts it into the HTML soup before extracting the tweet's text.

This pull request also forces the encoding of BeautifulSoup to be utf-8.

Original bug report: #9 
